### PR TITLE
Add versions sub-command to project command

### DIFF
--- a/internal/cmd/project/project.go
+++ b/internal/cmd/project/project.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/ankitpokhrel/jira-cli/internal/cmd/project/list"
+	"github.com/ankitpokhrel/jira-cli/internal/cmd/project/versions"
 )
 
 const helpText = `Project manages Jira projects. See available commands below.`
@@ -20,6 +21,7 @@ func NewCmdProject() *cobra.Command {
 	}
 
 	cmd.AddCommand(list.NewCmdList())
+	cmd.AddCommand(versions.NewCmdVersions())
 
 	return &cmd
 }

--- a/internal/cmd/project/versions/versions.go
+++ b/internal/cmd/project/versions/versions.go
@@ -1,0 +1,54 @@
+package versions
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+
+	"github.com/ankitpokhrel/jira-cli/api"
+	"github.com/ankitpokhrel/jira-cli/internal/cmdutil"
+	"github.com/ankitpokhrel/jira-cli/internal/view"
+	"github.com/ankitpokhrel/jira-cli/pkg/jira"
+)
+
+// NewCmdVersions is a versions command.
+func NewCmdVersions() *cobra.Command {
+	return &cobra.Command{
+		Use:     "versions",
+		Short:   "List newly created versions in a project",
+		Long:    "List newly created versions in a project.",
+		Aliases: []string{"version", "ver"},
+		Run:     Versions,
+	}
+}
+
+// Versions displays a list view of newly created versions.
+func Versions(cmd *cobra.Command, _ []string) {
+	project := viper.GetString("project.key")
+
+	debug, err := cmd.Flags().GetBool("debug")
+	cmdutil.ExitIfError(err)
+
+	versions, err := func() ([]*jira.Version, error) {
+		s := cmdutil.Info(fmt.Sprintf("Fetching versions in project %s...", project))
+		defer s.Stop()
+
+		resp, err := api.DefaultClient(debug).GetProjectVersions(project)
+		if err != nil {
+			return nil, err
+		}
+		return resp, nil
+	}()
+	cmdutil.ExitIfError(err)
+
+	if len(versions) == 0 {
+		fmt.Println()
+		cmdutil.Failed("No versions found in project %q", project)
+		return
+	}
+
+	v := view.NewVersion(versions)
+
+	cmdutil.ExitIfError(v.Render())
+}

--- a/pkg/jira/version.go
+++ b/pkg/jira/version.go
@@ -1,0 +1,37 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// Version represents a Jira version.
+type Version struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Released    bool   `json:"released"`
+	ReleaseDate string `json:"releaseDate"`
+}
+
+// GetProjectVersions fetches the versions for a given project.
+func (c *Client) GetProjectVersions(projectKey string) ([]*Version, error) {
+	res, err := c.GetV2(context.Background(), "/project/"+projectKey+"/versions", nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out []*Version
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return out, err
+}

--- a/pkg/jira/versions.go
+++ b/pkg/jira/versions.go
@@ -1,0 +1,37 @@
+package jira
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+)
+
+// Version represents a Jira version.
+type Version struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Released    bool   `json:"released"`
+	ReleaseDate string `json:"releaseDate"`
+}
+
+// GetProjectVersions fetches the versions for a given project.
+func (c *Client) GetProjectVersions(projectKey string) ([]*Version, error) {
+	res, err := c.GetV2(context.Background(), "/project/"+projectKey+"/versions", nil)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil {
+		return nil, ErrEmptyResponse
+	}
+	defer func() { _ = res.Body.Close() }()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, formatUnexpectedResponse(res)
+	}
+
+	var out []*Version
+	err = json.NewDecoder(res.Body).Decode(&out)
+
+	return out, err
+}


### PR DESCRIPTION
Add a new sub-command `versions` to the `project` command to list the newly created versions for a project.

* Modify `internal/cmd/project/project.go` to import the necessary packages and add the `versions` sub-command.
* Add `internal/cmd/project/versions/versions.go` to define the `NewCmdVersions` function and implement the `Versions` function to fetch and display the newly created versions for the project.
* Add `pkg/jira/version.go` to define the `Version` struct and implement the `GetProjectVersions` function to fetch the versions for a given project.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lroolle/jira-cli/pull/1?shareId=f42821cd-014d-43f1-8009-d29fa3fe0af9).